### PR TITLE
Veracode SCA: fixes for vulnerable libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,19 +18,19 @@
     <dependency>
       <groupId>org.apache.struts</groupId>
       <artifactId>struts2-core</artifactId>
-      <version>2.5.12</version>
+      <version>2.5.26-atlassian-2</version>
     </dependency>
 
     <dependency>
       <groupId>org.mindrot</groupId>
       <artifactId>jbcrypt</artifactId>
-      <version>0.3m</version>
+      <version>0.4-atlassian-1</version>
     </dependency>
 
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
-      <version>3.1.1.RELEASE</version>
+      <version>4.3.0.RC1</version>
     </dependency>
 
     <dependency>
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>1.3.176</version>
+      <version>2.1.210</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This pull request was generated by Veracode SCA to upgrade the following vulnerable libraries:

| Type | Library | From | To | Breaking |
| --- | --- | --- | --- | --- |
| MAVEN | `org.springframework:spring-web` | 3.1.1.RELEASE | 4.3.0.RC1 | Yes |
| MAVEN | `com.h2database:h2` | 1.3.176 | 2.1.210 | No |
| MAVEN | `org.apache.struts:struts2-core` | 2.5.12 | 2.5.26-atlassian-2 | No |
| MAVEN | `org.mindrot:jbcrypt` | 0.3m | 0.4-atlassian-1 | Yes |

Note that we only upgrade libraries which have versions without any known vulnerabilities. For more information, please see the corresponding [Veracode SCA report](https://sca.analysiscenter.veracode.com/teams/lDDIaXg/scans/35443353).

The **Breaking** column states the likelihood that updating to the recommended library version will cause breaking changes in your code. Please verify that the changes here won't cause issues with your project before merging.

To learn more about this feature, please visit our [Help Center](https://help.veracode.com/r/About_Automatic_Pull_Requests) for documentation.

Note: this pull request was generated because you or someone else with access to this repository granted Veracode SCA access to submit pull requests.
<!-- srcclr-pr-id-234c87ae4ad0ec418248acad97ffaa8f324d320f8f78e556ca9b7d558a9adf71 -->
