### PR TITLE
Veracode SCA: fixes for vulnerable libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>org.apache.struts</groupId>
       <artifactId>struts2-core</artifactId>
-      <version>2.5.12</version>
+      <version>2.5.30-atlassian-1</version>
     </dependency>
 
     <dependency>
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>1.3.176</version>
+      <version>2.1.210</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This pull request was generated by Veracode SCA to upgrade the following vulnerable libraries:

| Type | Library | From | To | Breaking |
| --- | --- | --- | --- | --- |
| MAVEN | `com.h2database:h2` | 1.3.176 | 2.1.210 | No |
| MAVEN | `org.apache.struts:struts2-core` | 2.5.12 | 2.5.30-atlassian-1 | No |

Note that we only upgrade libraries which have versions without any known vulnerabilities. For more information, please see the corresponding [Veracode SCA report](https://sca.analysiscenter.veracode.com/teams/3OOuvgA/scans/37731689).

The **Breaking** column states the likelihood that updating to the recommended library version will cause breaking changes in your code. Please verify that the changes here won't cause issues with your project before merging.

To learn more about this feature, please visit our [Help Center](https://help.veracode.com/r/About_Automatic_Pull_Requests) for documentation.

Note: this pull request was generated because you or someone else with access to this repository granted Veracode SCA access to submit pull requests.
<!-- srcclr-pr-id-ec28d573b824cb585ddf3f19e4a5444c79e698df218eeda245d13f2bb886067d -->
